### PR TITLE
fix: include FormsModule for BandControl

### DIFF
--- a/src/app/features/stage/band-control/band-control.component.ts
+++ b/src/app/features/stage/band-control/band-control.component.ts
@@ -1,10 +1,11 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { NgFor } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   standalone: true,
   selector: 'app-band-control',
-  imports: [NgFor],
+  imports: [NgFor, FormsModule],
   template: `
   <div class="panel">
     <h3>Band</h3>


### PR DESCRIPTION
## Summary
- import FormsModule into BandControlComponent so ngModel works for input

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6899ef425564832792f7dee12644cf9a