### PR TITLE
fix: use note strings after transposing chord

### DIFF
--- a/src/app/core/services/band-engine.service.ts
+++ b/src/app/core/services/band-engine.service.ts
@@ -41,7 +41,11 @@ export class BandEngineService {
       const chord = this.session.chord();
       const notes = this.chordToNotes(chord);
       this.keys?.triggerAttackRelease(notes, "1m", time);
-      this.gtr?.triggerAttackRelease(notes.map(n => Tone.Frequency(n).transpose(12)), "2n", time);
+      // Transpose the chord up one octave for the guitar part.
+      // `Tone.Frequency().transpose()` returns a FrequencyClass, which needs to
+      // be converted back to a note string for `triggerAttackRelease`.
+      const gtrNotes = notes.map(n => Tone.Frequency(n).transpose(12).toNote());
+      this.gtr?.triggerAttackRelease(gtrNotes, "2n", time);
     }, "1m").start(0);
 
     this.started = true;


### PR DESCRIPTION
## Summary
- convert transposed chord notes to note strings before triggering guitar synth

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6899f228d2a083278984f08cf8094a4a