### PR TITLE
feat: add mic level sound bar

### DIFF
--- a/src/app/core/audio/audio.service.ts
+++ b/src/app/core/audio/audio.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import { SessionStore } from '../state/session.store';
 
 @Injectable({ providedIn: 'root' })
@@ -9,6 +9,8 @@ export class AudioService {
   private rafId?: number;
   private onsetAr: number[] = [];
   private started = false;
+
+  readonly level = signal(0);
 
   constructor(private session: SessionStore) {}
 
@@ -34,6 +36,7 @@ export class AudioService {
       let sum = 0;
       for (let i = 0; i < buf.length; i++) sum += buf[i] * buf[i];
       const rms = Math.sqrt(sum / buf.length);
+      this.level.set(rms);
       this.onsetAr.push(rms);
       if (this.onsetAr.length > 6) this.onsetAr.shift();
 

--- a/src/app/features/stage/mic-level.component.ts
+++ b/src/app/features/stage/mic-level.component.ts
@@ -1,0 +1,20 @@
+import { Component, inject } from '@angular/core';
+import { AudioService } from '../../core/audio/audio.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-mic-level',
+  template: `
+  <div class="meter">
+    <div class="bar" [style.width.%]="level()*100"></div>
+  </div>
+  `,
+  styles: [`
+    .meter{height:.5rem;background:#e5e7eb;border-radius:.25rem;overflow:hidden;}
+    .bar{height:100%;background:#4ade80;transition:width .1s linear;}
+  `]
+})
+export class MicLevelComponent {
+  private audio = inject(AudioService);
+  level = this.audio.level;
+}

--- a/src/app/features/stage/stage.page.ts
+++ b/src/app/features/stage/stage.page.ts
@@ -6,14 +6,16 @@ import { BandEngineService } from '../../core/services/band-engine.service';
 import { BandHUDComponent } from './hud/band-hud.component';
 import { BandControlComponent } from './band-control/band-control.component';
 import { TransportControlsComponent } from './transport-controls.component';
+import { MicLevelComponent } from './mic-level.component';
 
 @Component({
   standalone: true,
   selector: 'app-stage',
-  imports: [NgIf, NgFor, BandHUDComponent, BandControlComponent, TransportControlsComponent],
+  imports: [NgIf, NgFor, BandHUDComponent, BandControlComponent, TransportControlsComponent, MicLevelComponent],
   template: `
   <section class="stage">
     <app-band-hud [hud]="session.hud()" />
+    <app-mic-level *ngIf="session.mode() !== 'IDLE'"></app-mic-level>
     <div class="row">
       <app-band-control
         [instruments]="session.instruments()"


### PR DESCRIPTION
## Summary
- expose microphone level in AudioService
- show a rehearsal mic level bar on the stage page

## Testing
- `npm test -- --watch=false` *(fails: Property 'title' does not exist on type 'AppComponent')*

------
https://chatgpt.com/codex/tasks/task_e_689a01681e1883278c6db94fdf64ccf6