### PR TITLE
feat: add style selector and backlog

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -14,16 +14,10 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'liveband-ai' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('liveband-ai');
-  });
-
-  it('should render title', () => {
+  it('should render header title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, liveband-ai');
+    expect(compiled.querySelector('h1')?.textContent).toContain('LiveBand AI');
   });
 });

--- a/src/app/core/services/band-engine.service.ts
+++ b/src/app/core/services/band-engine.service.ts
@@ -75,6 +75,10 @@ export class BandEngineService {
     // For MVP we won’t hard-remove; no-op here
   }
 
+  setStyle(style: string) {
+    // Switch patterns based on style (future work)
+  }
+
   private chordToNotes(sym: string): string[] {
     // Super-minimal triads for demo
     const map: Record<string, string[]> = {

--- a/src/app/features/stage/stage.page.ts
+++ b/src/app/features/stage/stage.page.ts
@@ -7,11 +7,12 @@ import { BandHUDComponent } from './hud/band-hud.component';
 import { BandControlComponent } from './band-control/band-control.component';
 import { TransportControlsComponent } from './transport-controls.component';
 import { MicLevelComponent } from './mic-level.component';
+import { StyleSelectorComponent } from './style-selector.component';
 
 @Component({
   standalone: true,
   selector: 'app-stage',
-  imports: [NgIf, NgFor, BandHUDComponent, BandControlComponent, TransportControlsComponent, MicLevelComponent],
+  imports: [NgIf, NgFor, BandHUDComponent, BandControlComponent, TransportControlsComponent, MicLevelComponent, StyleSelectorComponent],
   template: `
   <section class="stage">
     <app-band-hud [hud]="session.hud()" />
@@ -21,6 +22,7 @@ import { MicLevelComponent } from './mic-level.component';
         [instruments]="session.instruments()"
         (add)="onAdd($event)"
         (remove)="onRemove($event)"/>
+      <app-style-selector />
       <app-transport-controls
         (start)="start()"
         (stop)="stop()" />

--- a/src/app/features/stage/style-selector.component.ts
+++ b/src/app/features/stage/style-selector.component.ts
@@ -1,0 +1,34 @@
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { SessionStore } from '../../core/state/session.store';
+import { BandEngineService } from '../../core/services/band-engine.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-style-selector',
+  imports: [FormsModule],
+  template: `
+    <div class="panel">
+      <h3>Style</h3>
+      <select [(ngModel)]="style" (change)="onChange()">
+        <option value="pop_rock">Pop/Rock</option>
+        <option value="gospel">Gospel</option>
+        <option value="jazz">Jazz</option>
+      </select>
+    </div>
+  `,
+  styles: [`
+    .panel{border:1px solid #e5e7eb;padding:.75rem;border-radius:.5rem;min-width:200px}
+    select{padding:.4rem;border:1px solid #e5e7eb;border-radius:.25rem;width:100%}
+  `]
+})
+export class StyleSelectorComponent {
+  private session = inject(SessionStore);
+  private band = inject(BandEngineService);
+  style = this.session.style();
+
+  onChange() {
+    this.session.setStyle(this.style);
+    this.band.setStyle(this.style);
+  }
+}

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,13 @@
+# TODO
+
+- [ ] Mic input & onset detection enhancements
+- [ ] Pitch, key, chord, tempo estimation
+- [ ] Rehearsal mode with chart builder
+- [ ] Known song fingerprint matching
+- [ ] Band style presets and pattern overrides
+- [ ] Instrument add/remove with smooth transitions
+- [ ] Song library with save/load and cloud sync
+- [ ] Offline-first PWA caching
+- [ ] Accessibility (keyboard shortcuts, high-contrast)
+- [ ] Testing harness: unit, integration, e2e, audio accuracy
+- [ ] Telemetry (opt-in) for latency and accuracy


### PR DESCRIPTION
## Summary
- track outstanding product work in new todo.md
- allow selecting band style via new component on stage page
- stub style switching in band engine and update app tests

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a04446d90832782b8235ae14d89bd