### PR TITLE
feat: add library and settings pages

### DIFF
--- a/src/app/features/library/library.page.ts
+++ b/src/app/features/library/library.page.ts
@@ -1,9 +1,43 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { NgIf, NgFor } from '@angular/common';
 
 @Component({
   standalone: true,
   selector: 'app-library',
-  template: `<section class="page"><h2>Library</h2><p>(Coming soon)</p></section>`,
-  styles: [`.page{max-width:960px;margin:1rem auto;padding:1rem}`]
+  imports: [NgIf, NgFor],
+  template: `
+  <section class="page">
+    <h2>Library</h2>
+    <ng-container *ngIf="chart?.length; else empty">
+      <ol>
+        <li *ngFor="let ch of chart">{{ ch }}</li>
+      </ol>
+      <button (click)="clear()">Clear Last Chart</button>
+    </ng-container>
+    <ng-template #empty>
+      <p>No saved charts yet.</p>
+    </ng-template>
+  </section>
+  `,
+  styles: [`.page{max-width:960px;margin:1rem auto;padding:1rem}`],
 })
-export class LibraryPage {}
+export class LibraryPage implements OnInit {
+  chart: string[] | null = null;
+
+  ngOnInit() {
+    const saved = localStorage.getItem('lastChart');
+    if (saved) {
+      try {
+        this.chart = JSON.parse(saved);
+      } catch {
+        this.chart = null;
+      }
+    }
+  }
+
+  clear() {
+    localStorage.removeItem('lastChart');
+    this.chart = null;
+  }
+}
+

--- a/src/app/features/settings/settings.page.ts
+++ b/src/app/features/settings/settings.page.ts
@@ -1,9 +1,42 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 @Component({
   standalone: true,
   selector: 'app-settings',
-  template: `<section class="page"><h2>Settings</h2><p>(Coming soon)</p></section>`,
-  styles: [`.page{max-width:960px;margin:1rem auto;padding:1rem}`]
+  template: `
+  <section class="page">
+    <h2>Settings</h2>
+    <p>
+      <label>
+        <input type="checkbox" [checked]="theme==='dark'" (change)="toggleTheme()" />
+        Dark mode
+      </label>
+    </p>
+  </section>
+  `,
+  styles: [`.page{max-width:960px;margin:1rem auto;padding:1rem}`],
 })
-export class SettingsPage {}
+export class SettingsPage implements OnInit {
+  theme: 'light' | 'dark' = 'light';
+
+  ngOnInit() {
+    const saved = localStorage.getItem('theme');
+    if (saved === 'dark') {
+      this.theme = 'dark';
+      document.documentElement.classList.add('dark');
+    }
+  }
+
+  toggleTheme() {
+    if (this.theme === 'light') {
+      this.theme = 'dark';
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      this.theme = 'light';
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }
+}
+

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,3 +2,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./src/**/*.{html,ts}'],
+  darkMode: 'class',
   theme: { extend: {} },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- display last saved chart on Library page and allow clearing it
- add dark mode toggle in Settings and persist preference
- configure Tailwind for class-based dark mode and style body accordingly

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_689a23c0833483278830a767c121802f