### PR TITLE
feat: add persistent song library

### DIFF
--- a/src/app/features/library/library.page.spec.ts
+++ b/src/app/features/library/library.page.spec.ts
@@ -1,0 +1,42 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { LibraryPage } from './library.page';
+
+describe('LibraryPage', () => {
+  let component: LibraryPage;
+  let fixture: ComponentFixture<LibraryPage>;
+  let router: Router;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LibraryPage, RouterTestingModule]
+    }).compileComponents();
+    router = TestBed.inject(Router);
+    localStorage.setItem('charts', JSON.stringify([{ name: 'Test', chords: ['C', 'G'] }]));
+    fixture = TestBed.createComponent(LibraryPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('loads charts from storage', () => {
+    expect(component.charts.length).toBe(1);
+  });
+
+  it('load sets lastChart and navigates', () => {
+    spyOn(router, 'navigate');
+    component.load(0);
+    expect(localStorage.getItem('lastChart')).toBe(JSON.stringify(['C', 'G']));
+    expect(router.navigate).toHaveBeenCalledWith(['/stage']);
+  });
+
+  it('remove deletes chart', () => {
+    component.remove(0);
+    expect(component.charts.length).toBe(0);
+    expect(localStorage.getItem('charts')).toBe(JSON.stringify([]));
+  });
+});

--- a/src/app/features/library/library.page.ts
+++ b/src/app/features/library/library.page.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { NgIf, NgFor } from '@angular/common';
+import { Router } from '@angular/router';
 
 @Component({
   standalone: true,
@@ -8,11 +9,14 @@ import { NgIf, NgFor } from '@angular/common';
   template: `
   <section class="page">
     <h2>Library</h2>
-    <ng-container *ngIf="chart?.length; else empty">
+    <ng-container *ngIf="charts.length; else empty">
       <ol>
-        <li *ngFor="let ch of chart">{{ ch }}</li>
+        <li *ngFor="let c of charts; index as i">
+          {{ c.name }} ({{ c.chords.length }} chords)
+          <button (click)="load(i)">Load</button>
+          <button (click)="remove(i)">Delete</button>
+        </li>
       </ol>
-      <button (click)="clear()">Clear Last Chart</button>
     </ng-container>
     <ng-template #empty>
       <p>No saved charts yet.</p>
@@ -22,22 +26,29 @@ import { NgIf, NgFor } from '@angular/common';
   styles: [`.page{max-width:960px;margin:1rem auto;padding:1rem}`],
 })
 export class LibraryPage implements OnInit {
-  chart: string[] | null = null;
+  private router = inject(Router);
+  charts: { name: string; chords: string[] }[] = [];
 
   ngOnInit() {
-    const saved = localStorage.getItem('lastChart');
+    const saved = localStorage.getItem('charts');
     if (saved) {
       try {
-        this.chart = JSON.parse(saved);
+        this.charts = JSON.parse(saved);
       } catch {
-        this.chart = null;
+        this.charts = [];
       }
     }
   }
 
-  clear() {
-    localStorage.removeItem('lastChart');
-    this.chart = null;
+  load(i: number) {
+    const chart = this.charts[i];
+    localStorage.setItem('lastChart', JSON.stringify(chart.chords));
+    this.router.navigate(['/stage']);
+  }
+
+  remove(i: number) {
+    this.charts.splice(i, 1);
+    localStorage.setItem('charts', JSON.stringify(this.charts));
   }
 }
 

--- a/src/app/features/stage/stage.page.ts
+++ b/src/app/features/stage/stage.page.ts
@@ -75,6 +75,10 @@ export class StagePage {
   onTempo(bpm: number) { this.session.setTempo(bpm); this.band.setTempo(bpm); }
   onMetronome(on: boolean) { this.session.setMetronome(on); this.band.toggleMetronome(on); }
   saveChart() {
+    const name = window.prompt('Chart name?') || `Chart ${new Date().toLocaleString()}`;
+    const charts = JSON.parse(localStorage.getItem('charts') ?? '[]');
+    charts.push({ name, chords: this.chart });
+    localStorage.setItem('charts', JSON.stringify(charts));
     localStorage.setItem('lastChart', JSON.stringify(this.chart));
   }
   onAdd(name: string) { this.session.addInstrument(name); this.band.addInstrument(name); }


### PR DESCRIPTION
## Summary
- expand stage saving to support multiple named charts
- add library page to list, load, and delete saved charts
- cover library behavior with basic unit tests

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_689a628aa0f88327a65eee1238ca11b5