### PR TITLE
feat: add realtime audio analysis

### DIFF
--- a/src/app/core/audio/audio.service.ts
+++ b/src/app/core/audio/audio.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 import { SessionStore } from '../state/session.store';
+import { BandEngineService } from '../services/band-engine.service';
 
 @Injectable({ providedIn: 'root' })
 export class AudioService {
@@ -8,11 +9,15 @@ export class AudioService {
   private mic?: MediaStreamAudioSourceNode;
   private rafId?: number;
   private onsetAr: number[] = [];
+  private onsetTimes: number[] = [];
+  private pitchHist: number[] = [];
   private started = false;
+
+  private readonly NOTE_NAMES = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
 
   readonly level = signal(0);
 
-  constructor(private session: SessionStore) {}
+  constructor(private session: SessionStore, private band: BandEngineService) {}
 
   async initMic() {
     if (this.ctx) return;
@@ -40,12 +45,23 @@ export class AudioService {
       this.onsetAr.push(rms);
       if (this.onsetAr.length > 6) this.onsetAr.shift();
 
+      // pitch detection
+      const freq = this.detectPitch(buf);
+      if (freq > 0) {
+        const note = this.freqToNote(freq);
+        const pc = this.noteToClass(note);
+        this.pitchHist.push(pc);
+        if (this.pitchHist.length > 64) this.pitchHist.shift();
+        this.session.setPitch(note);
+        this.updateKeyAndChord();
+      }
+
       if (!this.started && this.onsetAr.length === 6) {
         const avg = (this.onsetAr[0]+this.onsetAr[1]+this.onsetAr[2]+this.onsetAr[3]+this.onsetAr[4]) / 5;
         const rising = this.onsetAr[5] > Math.max(0.08, avg * 2.8);
         if (rising) {
           this.started = true;
-          // Trigger band start
+          // Trigger band start and tempo update
           this.onOnset();
         }
       }
@@ -56,9 +72,69 @@ export class AudioService {
   }
 
   private onOnset() {
-    // Let the orchestrator (BandEngineService) decide FULL vs REHEARSAL later.
-    // For now: start default tempo/key.
-    if (!this.session.tempo()) this.session.setTempo(92);
+    const now = performance.now();
+    if (this.onsetTimes.length) {
+      const diff = now - this.onsetTimes[this.onsetTimes.length - 1];
+      const bpm = Math.round(60000 / diff);
+      this.session.setTempo(bpm);
+      this.band.setTempo(bpm);
+    }
+    this.onsetTimes.push(now);
+    if (this.onsetTimes.length > 8) this.onsetTimes.shift();
+  }
+
+  private updateKeyAndChord() {
+    if (!this.pitchHist.length) return;
+    const counts = new Array(12).fill(0);
+    for (const pc of this.pitchHist) counts[pc]++;
+    const keyIdx = counts.indexOf(Math.max(...counts));
+    const key = this.NOTE_NAMES[keyIdx];
+    this.session.setKey(key);
+
+    const recent = this.pitchHist.slice(-8);
+    const rc = new Array(12).fill(0);
+    for (const pc of recent) rc[pc]++;
+    const root = rc.indexOf(Math.max(...rc));
+    const hasMinor = rc[(root + 3) % 12] > 0;
+    const hasMajor = rc[(root + 4) % 12] > 0;
+    const hasFifth = rc[(root + 7) % 12] > 0;
+    if (hasFifth) {
+      const chord = this.NOTE_NAMES[root] + (hasMinor && !hasMajor ? 'm' : '');
+      this.session.setChord(chord);
+      this.band.setChord(chord);
+    }
+  }
+
+  private detectPitch(buf: Float32Array): number {
+    if (!this.ctx) return 0;
+    const sampleRate = this.ctx.sampleRate;
+    let bestOffset = -1;
+    let bestCorr = 0;
+    for (let offset = 8; offset < buf.length / 2; offset++) {
+      let corr = 0;
+      for (let i = 0; i < buf.length - offset; i++) {
+        corr += buf[i] * buf[i + offset];
+      }
+      corr /= buf.length - offset;
+      if (corr > bestCorr) { bestCorr = corr; bestOffset = offset; }
+    }
+    if (bestCorr > 0.3 && bestOffset > 0) {
+      return sampleRate / bestOffset;
+    }
+    return 0;
+  }
+
+  private freqToNote(freq: number): string {
+    const A4 = 440;
+    const n = Math.round(12 * Math.log2(freq / A4)) + 69;
+    const name = this.NOTE_NAMES[n % 12];
+    const octave = Math.floor(n / 12) - 1;
+    return `${name}${octave}`;
+  }
+
+  private noteToClass(note: string): number {
+    const name = note.replace(/\d/g, '');
+    return this.NOTE_NAMES.indexOf(name);
   }
 
   stop() {

--- a/src/app/core/state/session.store.ts
+++ b/src/app/core/state/session.store.ts
@@ -8,6 +8,7 @@ export class SessionStore {
   readonly key = signal<string | null>(null);
   readonly tempo = signal<number | null>(null);
   readonly chord = signal<string>('C');
+  readonly pitch = signal<string | null>(null);
   readonly instruments = signal<string[]>(['guitar','keys','drums']);
   readonly style = signal<string>('pop_rock');
   readonly metronome = signal<boolean>(false);
@@ -15,6 +16,7 @@ export class SessionStore {
   readonly hud = computed(() => ({
     mode: this.mode(),
     key: this.key(),
+    pitch: this.pitch(),
     chord: this.chord(),
     tempo: this.tempo() ?? 92,
     metronome: this.metronome(),
@@ -29,6 +31,7 @@ export class SessionStore {
   }
   setChord(c: string) { this.chord.set(c); }
   setKey(k: string | null) { this.key.set(k); }
+  setPitch(p: string | null) { this.pitch.set(p); }
   setTempo(bpm: number | null) { this.tempo.set(bpm); }
   setMode(m: Mode) { this.mode.set(m); }
   setStyle(s: string) { this.style.set(s); }

--- a/src/app/features/stage/hud/band-hud.component.ts
+++ b/src/app/features/stage/hud/band-hud.component.ts
@@ -7,6 +7,7 @@ import { Component, Input } from '@angular/core';
   <div class="hud">
     <div><label>Mode</label><strong>{{hud.mode}}</strong></div>
     <div><label>Key</label><strong>{{hud.key ?? '—'}}</strong></div>
+    <div><label>Pitch</label><strong>{{hud.pitch ?? '—'}}</strong></div>
     <div><label>Chord</label><strong>{{hud.chord}}</strong></div>
     <div><label>BPM</label><strong>{{hud.tempo}}</strong></div>
     <div><label>Metronome</label><strong>{{hud.metronome ? 'on' : 'off'}}</strong></div>
@@ -14,7 +15,7 @@ import { Component, Input } from '@angular/core';
   </div>
   `,
   styles: [`
-    .hud{display:grid;grid-template-columns:repeat(6,1fr);gap:.5rem;
+    .hud{display:grid;grid-template-columns:repeat(7,1fr);gap:.5rem;
       padding:.75rem;border:1px solid #e5e7eb;border-radius:.5rem;background:#fafafa}
     label{display:block;font-size:.75rem;color:#6b7280}
     strong{font-size:1.1rem}
@@ -23,6 +24,6 @@ import { Component, Input } from '@angular/core';
 })
 export class BandHUDComponent {
   @Input({ required: true }) hud!: {
-    mode: string; key: string|null; chord: string; tempo: number; metronome: boolean; instruments: string[];
+    mode: string; key: string|null; pitch: string|null; chord: string; tempo: number; metronome: boolean; instruments: string[];
   };
 }

--- a/todo.md
+++ b/todo.md
@@ -1,7 +1,7 @@
 # TODO
 
   - [x] Mic input & onset detection enhancements
-  - [ ] Pitch, key, chord, tempo estimation
+  - [x] Pitch, key, chord, tempo estimation
   - [x] Rehearsal mode with chart builder
   - [ ] Known song fingerprint matching
   - [ ] Band style presets and pattern overrides


### PR DESCRIPTION
## Summary
- implement microphone-based pitch detection, key/chord inference, and tempo estimation
- expose detected pitch/key/chord/tempo via session store and HUD
- simplify stage page by removing mock analysis stream

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_689a7012723483278d1f9922bd6280c2