### PR TITLE
feat: add known song fingerprint matching

### DIFF
--- a/src/app/core/services/fingerprint.service.ts
+++ b/src/app/core/services/fingerprint.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, effect, inject } from '@angular/core';
+import { SessionStore } from '../state/session.store';
+import { BandEngineService } from './band-engine.service';
+
+interface Fingerprint {
+  name: string;
+  chords: string[];
+  key: string;
+  tempo: number;
+}
+
+const FINGERPRINTS: Fingerprint[] = [
+  { name: 'Canon', chords: ['C', 'Am', 'F', 'G'], key: 'C', tempo: 92 }
+];
+
+@Injectable({ providedIn: 'root' })
+export class FingerprintService {
+  private session = inject(SessionStore);
+  private band = inject(BandEngineService);
+
+  private history: string[] = [];
+  private matched = false;
+  private readonly maxUnmatched = 8;
+
+  constructor() {
+    effect(() => {
+      const mode = this.session.mode();
+      if (mode === 'LISTENING') {
+        this.history = [];
+        this.matched = false;
+      }
+    });
+
+    effect(() => {
+      const mode = this.session.mode();
+      const chord = this.session.chord();
+      if (mode !== 'LISTENING') return;
+      if (!this.history.length || this.history[this.history.length - 1] !== chord) {
+        this.history.push(chord);
+        if (this.history.length > this.maxUnmatched) {
+          this.session.setMode('REHEARSAL');
+          return;
+        }
+        this.checkMatch();
+      }
+    });
+  }
+
+  private checkMatch() {
+    for (const fp of FINGERPRINTS) {
+      const len = this.history.length;
+      if (len > fp.chords.length) continue;
+      const slice = this.history.slice(-len);
+      const target = fp.chords.slice(0, len);
+      const match = slice.every((c, i) => c === target[i]);
+      if (match) {
+        if (len === fp.chords.length) {
+          this.session.setMode('FULL');
+          this.session.setKey(fp.key);
+          this.session.setTempo(fp.tempo);
+          this.band.setTempo(fp.tempo);
+          this.matched = true;
+        }
+        return;
+      }
+    }
+  }
+}
+

--- a/src/app/core/services/gateway.service.ts
+++ b/src/app/core/services/gateway.service.ts
@@ -84,8 +84,12 @@ export class GatewayService {
       this.band.setChord(e.chord);
     }
     // Optionally adjust mode once first event arrives
-    if (this.session.mode() === 'LISTENING') {
-      this.session.setMode('FULL'); // mock "known song" for demo
+      if (this.session.mode() === 'LISTENING') {
+        if (e.conf && e.conf > 0.8) {
+          this.session.setMode('FULL');
+        } else {
+          this.session.setMode('REHEARSAL');
+        }
+      }
     }
   }
-}

--- a/src/app/features/stage/stage.page.ts
+++ b/src/app/features/stage/stage.page.ts
@@ -3,6 +3,7 @@ import { NgIf, NgFor } from '@angular/common';
 import { SessionStore } from '../../core/state/session.store';
 import { AudioService } from '../../core/audio/audio.service';
 import { BandEngineService } from '../../core/services/band-engine.service';
+import { FingerprintService } from '../../core/services/fingerprint.service';
 import { BandHUDComponent } from './hud/band-hud.component';
 import { BandControlComponent } from './band-control/band-control.component';
 import { TransportControlsComponent } from './transport-controls.component';
@@ -43,6 +44,7 @@ export class StagePage {
   session = inject(SessionStore);
   private audio = inject(AudioService);
   private band = inject(BandEngineService);
+  private fp = inject(FingerprintService);
   private chart: string[] = [];
 
   private record = effect(() => {
@@ -58,8 +60,7 @@ export class StagePage {
   async start() {
     await this.band.prepare();        // boot Tone + patterns
     await this.audio.initMic();       // ask mic permission
-    this.session.setMode('LISTENING');// until analysis locks on
-    this.session.setMode('REHEARSAL');// until we add known-song matching
+    this.session.setMode('LISTENING');// wait for fingerprint match
     this.chart = [];
   }
   stop() {

--- a/todo.md
+++ b/todo.md
@@ -3,7 +3,7 @@
   - [x] Mic input & onset detection enhancements
   - [x] Pitch, key, chord, tempo estimation
   - [x] Rehearsal mode with chart builder
-  - [ ] Known song fingerprint matching
+  - [x] Known song fingerprint matching
   - [ ] Band style presets and pattern overrides
   - [ ] Instrument add/remove with smooth transitions
   - [x] Song library with save/load and cloud sync


### PR DESCRIPTION
## Summary
- implement fingerprint service to match chord progressions to known songs
- integrate fingerprint matching into stage flow and gateway confidence handling
- mark known song fingerprint matching as complete in todo

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_689a723294c483278afe031a054d9956