### PR TITLE
feat: add style presets and pattern overrides

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -4,7 +4,7 @@
   - [x] Pitch, key, chord, tempo estimation
   - [x] Rehearsal mode with chart builder
   - [x] Known song fingerprint matching
-  - [ ] Band style presets and pattern overrides
+  - [x] Band style presets and pattern overrides
   - [ ] Instrument add/remove with smooth transitions
   - [x] Song library with save/load and cloud sync
   - [x] Offline-first PWA caching


### PR DESCRIPTION
## Summary
- define drum pattern presets for pop_rock, gospel, and jazz styles
- allow runtime style switching and drum pattern overrides in BandEngineService
- mark style preset TODO as complete

## Testing
- `npm test -- --browsers=ChromeHeadless --watch=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_689a796a83e48327bc760eecf82c5459