### PR TITLE
feat: add accessibility shortcuts and high contrast theme

### DIFF
--- a/src/app/features/settings/settings.page.ts
+++ b/src/app/features/settings/settings.page.ts
@@ -12,18 +12,30 @@ import { Component, OnInit } from '@angular/core';
         Dark mode
       </label>
     </p>
+    <p>
+      <label>
+        <input type="checkbox" [checked]="highContrast" (change)="toggleHighContrast()" />
+        High contrast
+      </label>
+    </p>
   </section>
   `,
   styles: [`.page{max-width:960px;margin:1rem auto;padding:1rem}`],
 })
 export class SettingsPage implements OnInit {
   theme: 'light' | 'dark' = 'light';
+  highContrast = false;
 
   ngOnInit() {
     const saved = localStorage.getItem('theme');
     if (saved === 'dark') {
       this.theme = 'dark';
       document.documentElement.classList.add('dark');
+    }
+    const contrast = localStorage.getItem('contrast');
+    if (contrast === 'high') {
+      this.highContrast = true;
+      document.documentElement.classList.add('hc');
     }
   }
 
@@ -36,6 +48,17 @@ export class SettingsPage implements OnInit {
       this.theme = 'light';
       document.documentElement.classList.remove('dark');
       localStorage.setItem('theme', 'light');
+    }
+  }
+
+  toggleHighContrast() {
+    this.highContrast = !this.highContrast;
+    if (this.highContrast) {
+      document.documentElement.classList.add('hc');
+      localStorage.setItem('contrast', 'high');
+    } else {
+      document.documentElement.classList.remove('hc');
+      localStorage.setItem('contrast', 'normal');
     }
   }
 }

--- a/src/app/features/stage/stage.page.ts
+++ b/src/app/features/stage/stage.page.ts
@@ -1,4 +1,4 @@
-import { Component, inject, effect } from '@angular/core';
+import { Component, inject, effect, HostListener } from '@angular/core';
 import { NgIf, NgFor } from '@angular/common';
 import { SessionStore } from '../../core/state/session.store';
 import { AudioService } from '../../core/audio/audio.service';
@@ -79,5 +79,27 @@ export class StagePage {
   onAdd(name: string) { this.session.addInstrument(name); this.band.addInstrument(name); }
   onRemove(name: string) { this.session.removeInstrument(name); this.band.removeInstrument(name); }
 
-  
+  @HostListener('window:keydown', ['$event'])
+  handleKey(e: KeyboardEvent) {
+    const target = e.target as HTMLElement;
+    const tag = target.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || (target as any).isContentEditable) {
+      return;
+    }
+    if (e.code === 'Space') {
+      e.preventDefault();
+      if (this.session.mode() === 'IDLE') {
+        this.start();
+      } else {
+        this.stop();
+      }
+    } else if (e.key.toLowerCase() === 'm') {
+      e.preventDefault();
+      this.onMetronome(!this.session.metronome());
+    } else if ((e.key.toLowerCase() === 's') && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      this.saveChart();
+    }
+  }
+
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,3 +6,15 @@
 body {
   @apply bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100;
 }
+
+:root.hc body {
+  @apply bg-black text-white;
+}
+
+:root.hc .panel,
+:root.hc .hud,
+:root.hc button,
+:root.hc input,
+:root.hc select {
+  @apply bg-black text-white border-white;
+}

--- a/todo.md
+++ b/todo.md
@@ -8,6 +8,6 @@
   - [x] Instrument add/remove with smooth transitions
   - [x] Song library with save/load and cloud sync
   - [x] Offline-first PWA caching
-  - [ ] Accessibility (keyboard shortcuts, high-contrast)
+  - [x] Accessibility (keyboard shortcuts, high-contrast)
   - [ ] Testing harness: unit, integration, e2e, audio accuracy
   - [ ] Telemetry (opt-in) for latency and accuracy


### PR DESCRIPTION
## Summary
- add keyboard shortcuts for stage start/stop, metronome toggle, and chart save
- provide optional high-contrast theme with persistent setting
- mark accessibility work complete in TODO

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless; set CHROME_BIN)*
- `apt-get update` *(fails: repository InRelease not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_689a950024c0832785a0997f53469e44