### PR TITLE
Make stage controls responsive for mobile

### DIFF
--- a/src/app/features/stage/band-control/band-control.component.ts
+++ b/src/app/features/stage/band-control/band-control.component.ts
@@ -21,11 +21,13 @@ import { FormsModule } from '@angular/forms';
   </div>
   `,
   styles: [`
+    :host{display:block}
     .panel{border:1px solid #e5e7eb;padding:.75rem;border-radius:.5rem;min-width:260px}
     .chips{display:flex;gap:.5rem;flex-wrap:wrap;margin-bottom:.5rem}
     .chip{border:1px solid #e5e7eb;padding:.25rem .5rem;border-radius:1rem}
     input{padding:.4rem;border:1px solid #e5e7eb;border-radius:.25rem;margin-right:.5rem}
     button{padding:.4rem .7rem;border:1px solid #e5e7eb;border-radius:.25rem;background:#fff;cursor:pointer}
+    @media (max-width:640px){.panel{min-width:0;width:100%}}
   `]
 })
 export class BandControlComponent {

--- a/src/app/features/stage/stage.page.ts
+++ b/src/app/features/stage/stage.page.ts
@@ -38,6 +38,7 @@ import { StyleSelectorComponent } from './style-selector.component';
   styles: [`
     .stage{max-width:960px;margin:1rem auto;padding:1rem}
     .row{display:flex;gap:1rem;flex-wrap:wrap}
+    @media (max-width:640px){.row{flex-direction:column}}
   `]
 })
 export class StagePage {

--- a/src/app/features/stage/style-selector.component.ts
+++ b/src/app/features/stage/style-selector.component.ts
@@ -18,8 +18,10 @@ import { BandEngineService } from '../../core/services/band-engine.service';
     </div>
   `,
   styles: [`
+    :host{display:block}
     .panel{border:1px solid #e5e7eb;padding:.75rem;border-radius:.5rem;min-width:200px}
     select{padding:.4rem;border:1px solid #e5e7eb;border-radius:.25rem;width:100%}
+    @media (max-width:640px){.panel{min-width:0;width:100%}}
   `]
 })
 export class StyleSelectorComponent {

--- a/src/app/features/stage/transport-controls.component.ts
+++ b/src/app/features/stage/transport-controls.component.ts
@@ -20,10 +20,12 @@ import { Component, EventEmitter, Output, Input } from '@angular/core';
     </div>
   `,
   styles: [`
+    :host{display:block}
     .panel{border:1px solid #e5e7eb;padding:.75rem;border-radius:.5rem}
     .row{display:flex;gap:.5rem;align-items:center;flex-wrap:wrap}
     button{padding:.5rem .9rem;border:1px solid #e5e7eb;border-radius:.25rem;background:#fff;cursor:pointer}
     .tempo{display:flex;align-items:center;gap:.25rem}
+    @media (max-width:640px){.panel{width:100%}}
   `]
 })
 export class TransportControlsComponent {


### PR DESCRIPTION
## Summary
- ensure stage layout stacks vertically on small screens
- allow band, style, and transport panels to expand full width on mobile

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_689a98603a1083279d48d1493324be87