### PR TITLE
feat: add basic recording support

### DIFF
--- a/src/app/core/audio/recording.service.ts
+++ b/src/app/core/audio/recording.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import * as Tone from 'tone';
+import { AudioService } from './audio.service';
+
+@Injectable({ providedIn: 'root' })
+export class RecordingService {
+  private dest = (Tone.getContext().rawContext as AudioContext).createMediaStreamDestination();
+  private recorder?: MediaRecorder;
+  private chunks: Blob[] = [];
+
+  constructor(private audio: AudioService) {
+    // route band output into recording destination
+    Tone.Destination.connect(this.dest);
+  }
+
+  async start() {
+    this.audio.connectRecorder(this.dest);
+    this.chunks = [];
+    this.recorder = new MediaRecorder(this.dest.stream);
+    this.recorder.ondataavailable = e => this.chunks.push(e.data);
+    this.recorder.start();
+  }
+
+  async stop(): Promise<string> {
+    return new Promise(resolve => {
+      if (!this.recorder) {
+        resolve('');
+        return;
+      }
+      this.recorder.onstop = () => {
+        const blob = new Blob(this.chunks, { type: 'audio/webm' });
+        const url = URL.createObjectURL(blob);
+        this.audio.disconnectRecorder(this.dest);
+        resolve(url);
+      };
+      this.recorder.stop();
+    });
+  }
+}

--- a/src/app/features/stage/transport-controls.component.ts
+++ b/src/app/features/stage/transport-controls.component.ts
@@ -1,8 +1,10 @@
 import { Component, EventEmitter, Output, Input } from '@angular/core';
+import { NgIf } from '@angular/common';
 
 @Component({
   standalone: true,
   selector: 'app-transport-controls',
+  imports: [NgIf],
   template: `
     <div class="panel">
       <h3>Transport</h3>
@@ -15,6 +17,8 @@ import { Component, EventEmitter, Output, Input } from '@angular/core';
         </label>
         <label><input type="checkbox" [checked]="metronome"
           (change)="metronomeChange.emit($any($event.target).checked)">Click</label>
+        <button (click)="record.emit()">{{recording ? 'Stop Rec' : 'Record'}}</button>
+        <audio *ngIf="recordingUrl" [src]="recordingUrl" controls></audio>
         <button (click)="save.emit()">Save Chart</button>
       </div>
     </div>
@@ -33,7 +37,10 @@ export class TransportControlsComponent {
   @Output() stop = new EventEmitter<void>();
   @Input() tempo = 92;
   @Input() metronome = false;
+  @Input() recording = false;
+  @Input() recordingUrl: string | null = null;
   @Output() tempoChange = new EventEmitter<number>();
   @Output() metronomeChange = new EventEmitter<boolean>();
   @Output() save = new EventEmitter<void>();
+  @Output() record = new EventEmitter<void>();
 }


### PR DESCRIPTION
## Summary
- enable microphone analysis in Tone.js context for recording
- add recording service using MediaRecorder to capture band mix
- expose record controls with playback link on stage

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a9e535c048327b909ca4ad9e6b680