### PR TITLE
feat: add download link for recordings

### DIFF
--- a/src/app/features/stage/transport-controls.component.spec.ts
+++ b/src/app/features/stage/transport-controls.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TransportControlsComponent } from './transport-controls.component';
+
+describe('TransportControlsComponent', () => {
+  let component: TransportControlsComponent;
+  let fixture: ComponentFixture<TransportControlsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TransportControlsComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TransportControlsComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('shows download link when recordingUrl is set', () => {
+    component.recordingUrl = 'blob:test';
+    fixture.detectChanges();
+    const link = fixture.debugElement.query(By.css('a.download'));
+    expect(link).toBeTruthy();
+    expect(link.nativeElement.getAttribute('href')).toBe('blob:test');
+  });
+});

--- a/src/app/features/stage/transport-controls.component.ts
+++ b/src/app/features/stage/transport-controls.component.ts
@@ -19,6 +19,7 @@ import { NgIf } from '@angular/common';
           (change)="metronomeChange.emit($any($event.target).checked)">Click</label>
         <button (click)="record.emit()">{{recording ? 'Stop Rec' : 'Record'}}</button>
         <audio *ngIf="recordingUrl" [src]="recordingUrl" controls></audio>
+        <a *ngIf="recordingUrl" [href]="recordingUrl" download="recording.webm" class="download">Download</a>
         <button (click)="save.emit()">Save Chart</button>
       </div>
     </div>
@@ -28,6 +29,7 @@ import { NgIf } from '@angular/common';
     .panel{border:1px solid #e5e7eb;padding:.75rem;border-radius:.5rem}
     .row{display:flex;gap:.5rem;align-items:center;flex-wrap:wrap}
     button{padding:.5rem .9rem;border:1px solid #e5e7eb;border-radius:.25rem;background:#fff;cursor:pointer}
+    a.download{padding:.5rem .9rem;border:1px solid #e5e7eb;border-radius:.25rem;background:#fff;cursor:pointer;text-decoration:none;color:inherit}
     .tempo{display:flex;align-items:center;gap:.25rem}
     @media (max-width:640px){.panel{width:100%}}
   `]


### PR DESCRIPTION
## Summary
- add download anchor to transport controls so recorded audio can be saved
- cover transport controls with a unit test for the download link

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689ab3e0b82c8327bb39ae8ced16e41e